### PR TITLE
Potential fix for code scanning alert no. 2: Disabled Spring CSRF protection

### DIFF
--- a/src/main/java/ph/edu/cspb/form137/config/SecurityConfig.java
+++ b/src/main/java/ph/edu/cspb/form137/config/SecurityConfig.java
@@ -34,7 +34,6 @@ public class SecurityConfig {
         } else {
             http
                 .authorizeHttpRequests(authz -> authz.anyRequest().permitAll())
-                .csrf(AbstractHttpConfigurer::disable)
                 .cors(Customizer.withDefaults());
         }
         return http.build();


### PR DESCRIPTION
Potential fix for [https://github.com/cspb1913/form137-api/security/code-scanning/2](https://github.com/cspb1913/form137-api/security/code-scanning/2)

To fix the issue, CSRF protection should remain enabled by default, even when `authEnabled` is `false`. If there are specific endpoints or scenarios where CSRF protection is not required, these should be explicitly configured using Spring Security's CSRF configuration options. 

The best way to fix the problem is to remove the line disabling CSRF protection (`http.csrf(AbstractHttpConfigurer::disable)`) and allow Spring Security's default CSRF protection to remain active. If CSRF protection needs to be disabled for specific endpoints, this should be done selectively rather than globally.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
