### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/cspb1913/form137-api/security/code-scanning/1](https://github.com/cspb1913/form137-api/security/code-scanning/1)

To fix this issue, we need to add a `permissions` block to the workflow at the root level or inside the job (under `jobs.build-and-push`). The permissions should be set to the least privilege needed for the workflow to function. Since the workflow involves reading repository contents and interacting with external Docker actions, the minimal permissions needed are likely `contents: read`.

We will insert the `permissions` block at the root of the workflow to apply it globally to all jobs, ensuring consistent permission settings across the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
